### PR TITLE
Add CounterApp sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,8 @@ let main _ =
 Post the Increment command to counter 1: `curl localhost:8080/counters/1 -d '"Increment"'`
 
 Get the current state of counter 1: `curl localhost:8080/counters/1`
+
+### Running the CounterApp sample
+
+Run `dotnet run --project samples/CounterApp/CounterApp.fsproj` to start the web API, then use the curl commands above to interact with it.
+

--- a/samples/CounterApp/CounterApp.fsproj
+++ b/samples/CounterApp/CounterApp.fsproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>false</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../event-modeling.fsproj" />
+  </ItemGroup>
+</Project>

--- a/samples/CounterApp/Program.fs
+++ b/samples/CounterApp/Program.fs
@@ -1,0 +1,47 @@
+open System
+open Suave
+
+// Domain model from README
+
+type Event =
+    | Incremented
+    | Decremented
+    interface TypeShape.UnionContract.IUnionContract
+
+type Command =
+    | Increment
+    | Decrement
+
+type State =
+    | Zero
+    | Succ of State
+
+let counterDecider : CommandPattern.Decider<State, Command, Event> = {
+    initial = Zero
+    decide = fun cmd state ->
+        match cmd, state with
+        | Increment, _ -> [ Incremented ]
+        | Decrement, Zero -> []
+        | Decrement, Succ _ -> [ Decremented ]
+    evolve = fun state event ->
+        match event, state with
+        | Incremented, _ -> Succ state
+        | Decremented, Zero -> Zero
+        | Decremented, Succ state' -> state'
+}
+
+[<EntryPoint>]
+let main _ =
+    let service = Service.createService counterDecider "Counter" None
+    let _ : IDisposable =
+        service.Subscribe (fun name events -> printfn "%A" (name, events))
+    let app =
+        GenericResource.configure
+            "Counter"
+            "/counters/%s"
+            "/counters/%s/%s"
+            service
+            []
+    Suave.Web.startWebServer Suave.Web.defaultConfig app
+    0
+


### PR DESCRIPTION
## Summary
- add simple CounterApp console project demonstrating `Service.createService` and `GenericResource.configure`
- document how to run the sample in the README

## Testing
- `dotnet build samples/CounterApp/CounterApp.fsproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683da01a9ff88330ae14cb9f235f7355