### PR TITLE
Fix view projection type mismatch

### DIFF
--- a/samples/ViewApp/Program.fs
+++ b/samples/ViewApp/Program.fs
@@ -53,7 +53,7 @@ let main _ =
             "/counters/%s"
             "/counters/%s/%s"
             service
-            [ "count", countProjection
-              "history", historyProjection ]
+            [ GenericResource.boxProjection "count" countProjection
+              GenericResource.boxProjection "history" historyProjection ]
     Suave.Web.startWebServer Suave.Web.defaultConfig app
     0


### PR DESCRIPTION
## Summary
- allow `GenericResource.configure` to take views with different view types
- update `ViewApp` to use the boxed projections

## Testing
- `dotnet build --nologo`
- `dotnet build samples/CounterApp/CounterApp.fsproj --nologo` *(fails: no network)*

------
https://chatgpt.com/codex/tasks/task_b_683de8c4f22083309ad392aedf7d4306