### PR TITLE
Add initial Expecto tests and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '7.x'
+      - name: Restore
+        run: dotnet restore
+      - name: Run Tests
+        run: dotnet test tests/EventModeling.Tests/EventModeling.Tests.fsproj --no-build

--- a/tests/EventModeling.Tests/EventModeling.Tests.fsproj
+++ b/tests/EventModeling.Tests/EventModeling.Tests.fsproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Tests.fs" />
+    <ProjectReference Include="../event-modeling.fsproj" />
+    <PackageReference Include="Expecto" Version="9.0.4" />
+  </ItemGroup>
+</Project>

--- a/tests/EventModeling.Tests/Tests.fs
+++ b/tests/EventModeling.Tests/Tests.fs
@@ -1,0 +1,70 @@
+module EventModeling.Tests
+
+open Expecto
+open CommandPattern
+
+// Domain types and decider as in README
+
+type Event =
+    | Incremented
+    | Decremented
+    interface TypeShape.UnionContract.IUnionContract
+
+type Command =
+    | Increment
+    | Decrement
+
+type State =
+    | Zero
+    | Succ of State
+
+let counterDecider : Decider<State, Command, Event> = {
+    initial = Zero
+    decide = fun cmd state ->
+        match cmd, state with
+        | Increment, _ -> [ Incremented ]
+        | Decrement, Zero -> []
+        | Decrement, Succ _ -> [ Decremented ]
+    evolve = fun state event ->
+        match event, state with
+        | Incremented, _ -> Succ state
+        | Decremented, Zero -> Zero
+        | Decremented, Succ s -> s
+}
+
+let countProjection : Projection<int, Event> =
+    { initial = 0
+      project = fun count -> function
+        | Incremented -> count + 1
+        | Decremented -> count - 1 }
+
+[<Tests>]
+let executeTests =
+    testList "execute" [
+        testCase "returns no events when decrementing zero" <| fun _ ->
+            let events = execute counterDecider [] Decrement
+            Expect.equal events [] "No events should be produced"
+
+        testCase "returns event when decrementing successor" <| fun _ ->
+            let history = [ Incremented ]
+            let events = execute counterDecider history Decrement
+            Expect.equal events [ Decremented ] "Decrement event expected"
+    ]
+
+[<Tests>]
+let hydrateTests =
+    testList "hydrate" [
+        testCase "recreates state from history" <| fun _ ->
+            let history = [ Incremented; Incremented; Decremented ]
+            let state = CommandPattern.hydrate counterDecider history
+            Expect.equal state (Succ Zero) "State should equal Succ Zero"
+
+        testCase "projects view from history" <| fun _ ->
+            let history = [ Incremented; Decremented; Incremented ]
+            let count = ViewPattern.hydrate countProjection history
+            Expect.equal count 1 "Count should be 1"
+    ]
+
+[<EntryPoint>]
+let main args =
+    runTestsInAssembly defaultConfig args


### PR DESCRIPTION
## Summary
- add Expecto-based test project for command and view patterns
- verify `execute` and both `hydrate` functions
- run tests in GitHub Actions
- fix ambiguous call in tests

## Testing
- `dotnet build`
- `dotnet build tests/EventModeling.Tests/EventModeling.Tests.fsproj --no-restore` *(fails: Expecto package not reachable)*
- `dotnet test tests/EventModeling.Tests/EventModeling.Tests.fsproj -v minimal` *(fails: No route to host)*


------
https://chatgpt.com/codex/tasks/task_b_683e0f3d68f48330a8b336274cb27c74