### PR TITLE
Downgrade to .NET 8

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "C# (.NET)",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/dotnet:1-9.0-bookworm",
+        "image": "mcr.microsoft.com/devcontainers/dotnet:1-8.0-bookworm",
 	"features": {
 		"ghcr.io/devcontainers/features/dotnet:2": {}
 	}

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '9.x'
+          dotnet-version: '8.x'
 
       - name: Authenticate GitHub Packages
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '9.x'
+          dotnet-version: '8.x'
       - name: Restore
         run: dotnet restore
       - name: Run Tests

--- a/event-modeling.fsproj
+++ b/event-modeling.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>event_modeling</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>0.18.0</Version>

--- a/samples/CounterApp/CounterApp.fsproj
+++ b/samples/CounterApp/CounterApp.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>false</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/ViewApp/ViewApp.fsproj
+++ b/samples/ViewApp/ViewApp.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>false</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/EventModeling.Tests/EventModeling.Tests.fsproj
+++ b/tests/EventModeling.Tests/EventModeling.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- update devcontainer to .NET 8 image
- target .NET 8 in all projects
- use .NET 8 in workflows

## Testing
- `dotnet test tests/EventModeling.Tests/EventModeling.Tests.fsproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ed228fae88330999e66b4b10ad4ef