### PR TITLE
Add automation and translation samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,11 @@ let counterService =
 
 When `counterService` commits new events, the translator is invoked for each of them. Any produced commands are executed on the `mirrorService` using the same stream identifier. This example mirrors events within the same category, but by supplying a mapping function you could translate between different categories or even use completely different stream identifiers.
 
+### Running the AutomationApp sample
+
+Run `dotnet run --project samples/AutomationApp/AutomationApp.fsproj` to start a service that automatically issues an `Increment` command whenever the counter reaches zero.
+
+### Running the TranslationApp sample
+
+Run `dotnet run --project samples/TranslationApp/TranslationApp.fsproj` to start two services where increment events from the `Counter` category are translated into `Increment` commands for the `Mirror` category.
+

--- a/samples/AutomationApp/AutomationApp.fsproj
+++ b/samples/AutomationApp/AutomationApp.fsproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>false</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+    <ProjectReference Include="../../event-modeling.fsproj" />
+  </ItemGroup>
+</Project>

--- a/samples/AutomationApp/Program.fs
+++ b/samples/AutomationApp/Program.fs
@@ -1,0 +1,63 @@
+open System
+open Suave
+
+// Domain model from README
+
+type Event =
+    | Incremented
+    | Decremented
+    interface TypeShape.UnionContract.IUnionContract
+
+type Command =
+    | Increment
+    | Decrement
+
+type State =
+    | Zero
+    | Succ of State
+
+let counterDecider : CommandPattern.Decider<State, Command, Event> = {
+    initial = Zero
+    decide = fun cmd state ->
+        match cmd, state with
+        | Increment, _ -> [ Incremented ]
+        | Decrement, Zero -> []
+        | Decrement, Succ _ -> [ Decremented ]
+    evolve = fun state event ->
+        match event, state with
+        | Incremented, _ -> Succ state
+        | Decremented, Zero -> Zero
+        | Decremented, Succ state' -> state'
+}
+
+// Projection and automation trigger
+
+let countProjection : ViewPattern.Projection<int, Event> =
+    { initial = 0
+      project = fun count -> function
+        | Incremented -> count + 1
+        | Decremented -> count - 1 }
+
+let triggerIfZero count =
+    if count = 0 then Some Increment else None
+
+let automation : AutomationPattern.Automation<int, State, Event, Command> =
+    { projection = countProjection
+      trigger = triggerIfZero
+      decider = counterDecider }
+
+[<EntryPoint>]
+let main _ =
+    let service =
+        Service.createService counterDecider "Counter" (Some automation) None
+    let _ : IDisposable =
+        service.Subscribe (fun name events -> printfn "%A" (name, events))
+    let app =
+        GenericResource.configure
+            "Counter"
+            "/counters/%s"
+            "/counters/%s/%s"
+            service
+            [ GenericResource.boxProjection "count" countProjection ]
+    Suave.Web.startWebServer Suave.Web.defaultConfig app
+    0

--- a/samples/AutomationApp/README.md
+++ b/samples/AutomationApp/README.md
@@ -1,0 +1,24 @@
+# AutomationApp Sample
+
+This sample demonstrates the **Automation Pattern**. The counter service
+contains a trigger that automatically issues an `Increment` command whenever
+the counter value reaches zero.
+
+Run the sample with:
+
+```bash
+dotnet run --project samples/AutomationApp/AutomationApp.fsproj
+```
+
+Try the following sequence of commands:
+
+```bash
+# increment to 1
+curl localhost:8080/counters/1 -d '"Increment"'
+
+# decrement back to 0 – automation immediately increments again
+curl localhost:8080/counters/1 -d '"Decrement"'
+
+# inspect the current count (should be 1)
+curl localhost:8080/counters/1/count
+```

--- a/samples/TranslationApp/Program.fs
+++ b/samples/TranslationApp/Program.fs
@@ -1,0 +1,83 @@
+open System
+open Suave
+
+// Domain model from README
+
+type Event =
+    | Incremented
+    | Decremented
+    interface TypeShape.UnionContract.IUnionContract
+
+type Command =
+    | Increment
+    | Decrement
+
+type State =
+    | Zero
+    | Succ of State
+
+let counterDecider : CommandPattern.Decider<State, Command, Event> = {
+    initial = Zero
+    decide = fun cmd state ->
+        match cmd, state with
+        | Increment, _ -> [ Incremented ]
+        | Decrement, Zero -> []
+        | Decrement, Succ _ -> [ Decremented ]
+    evolve = fun state event ->
+        match event, state with
+        | Incremented, _ -> Succ state
+        | Decremented, Zero -> Zero
+        | Decremented, Succ state' -> state'
+}
+
+// View projections demonstrating the ViewPattern
+
+let countProjection : ViewPattern.Projection<int, Event> =
+    { initial = 0
+      project = fun count -> function
+        | Incremented -> count + 1
+        | Decremented -> count - 1 }
+
+let lastEventProjection : ViewPattern.Projection<Event option, Event> =
+    { initial = None
+      project = fun _ e -> Some e }
+
+let mirrorTranslator : TranslationPattern.Translator<Event, Event option, Command> =
+    { projection = lastEventProjection
+      translate = function
+        | Some Incremented -> Some Increment
+        | _ -> None }
+
+let mirrorService =
+    Service.createService counterDecider "Mirror" None None
+
+let counterService =
+    Service.createService counterDecider "Counter" None (Some (mirrorTranslator, mirrorService))
+
+[<EntryPoint>]
+let main _ =
+    let _ : IDisposable =
+        counterService.Subscribe (fun name events -> printfn "%A" (name, events))
+    let _ : IDisposable =
+        mirrorService.Subscribe (fun name events -> printfn "%A" (name, events))
+
+    let counterApp =
+        GenericResource.configure
+            "Counter"
+            "/counters/%s"
+            "/counters/%s/%s"
+            counterService
+            [ GenericResource.boxProjection "count" countProjection ]
+
+    let mirrorApp =
+        GenericResource.configure
+            "Mirror"
+            "/mirror/%s"
+            "/mirror/%s/%s"
+            mirrorService
+            [ GenericResource.boxProjection "count" countProjection ]
+
+    let app = Suave.Operators.choose [ counterApp; mirrorApp ]
+
+    Suave.Web.startWebServer Suave.Web.defaultConfig app
+    0

--- a/samples/TranslationApp/README.md
+++ b/samples/TranslationApp/README.md
@@ -1,0 +1,28 @@
+# TranslationApp Sample
+
+This sample wires two counter services together using the **Translation Pattern**.
+Events from the `Counter` category are translated into commands for the
+`Mirror` category. In this example only `Incremented` events are mirrored as
+`Increment` commands.
+
+Run the sample with:
+
+```bash
+dotnet run --project samples/TranslationApp/TranslationApp.fsproj
+```
+
+Try the following commands:
+
+```bash
+# increment the main counter
+curl localhost:8080/counters/1 -d '"Increment"'
+
+# the mirror service has also incremented
+curl localhost:8080/mirror/1/count
+
+# decrement only affects the main counter
+curl localhost:8080/counters/1 -d '"Decrement"'
+
+# mirror count remains 1
+curl localhost:8080/mirror/1/count
+```

--- a/samples/TranslationApp/TranslationApp.fsproj
+++ b/samples/TranslationApp/TranslationApp.fsproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>false</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+    <ProjectReference Include="../../event-modeling.fsproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add AutomationApp sample to show the Automation Pattern
- add TranslationApp sample for the Translation Pattern
- document how to run the new samples

## Testing
- `dotnet build`
- `dotnet run --project tests/EventModeling.Tests/EventModeling.Tests.fsproj`

------
https://chatgpt.com/codex/tasks/task_b_683ee750431883309b9558914701089f