### PR TITLE
Add InventoryApp sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,7 @@ Run `dotnet run --project samples/AutomationApp/AutomationApp.fsproj` to start a
 
 Run `dotnet run --project samples/TranslationApp/TranslationApp.fsproj` to start two services where increment events from the `Counter` category are translated into `Increment` commands for the `Mirror` category.
 
+
+### Running the InventoryApp sample
+
+Run `dotnet run --project samples/InventoryApp/InventoryApp.fsproj` to start a minimal inventory service that demonstrates all four patterns with an automatic reorder workflow.

--- a/samples/InventoryApp/InventoryApp.fsproj
+++ b/samples/InventoryApp/InventoryApp.fsproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>false</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+    <ProjectReference Include="../../event-modeling.fsproj" />
+  </ItemGroup>
+</Project>

--- a/samples/InventoryApp/Program.fs
+++ b/samples/InventoryApp/Program.fs
@@ -1,0 +1,145 @@
+open System
+open Suave
+
+open CommandPattern
+open ViewPattern
+open AutomationPattern
+open TranslationPattern
+
+// Inventory domain types
+
+// Commands that can be issued to the inventory
+// Add or remove stock, or request a reorder internally
+
+type InventoryCommand =
+    | AddStock of int
+    | RemoveStock of int
+    | RequestReorder
+
+// Events emitted by the inventory
+
+type InventoryEvent =
+    | StockAdded of int
+    | StockRemoved of int
+    | ReorderRequested of int
+    interface TypeShape.UnionContract.IUnionContract
+
+// State is the current quantity on hand
+
+type InventoryState = int
+
+// Decider implementing the command pattern for inventory
+
+let inventoryDecider : Decider<InventoryState, InventoryCommand, InventoryEvent> =
+    {
+        initial = 0
+        decide = fun cmd state ->
+            match cmd with
+            | AddStock qty when qty > 0 ->
+                [ StockAdded qty ]
+            | RemoveStock qty when qty > 0 && state >= qty ->
+                [ StockRemoved qty ]
+            | RequestReorder ->
+                // request a fixed amount when stock is low
+                [ ReorderRequested 10 ]
+            | _ ->
+                []
+        evolve = fun state event ->
+            match event with
+            | StockAdded qty -> state + qty
+            | StockRemoved qty -> state - qty
+            | ReorderRequested _ -> state
+    }
+
+// Projection of current stock level (View pattern)
+
+let stockProjection : Projection<int, InventoryEvent> =
+    { initial = 0
+      project = fun current -> function
+        | StockAdded qty -> current + qty
+        | StockRemoved qty -> current - qty
+        | ReorderRequested _ -> current }
+
+// Automation to trigger reorder when stock below threshold
+
+let threshold = 5
+
+let lowStockAutomation : Automation<int, InventoryState, InventoryEvent, InventoryCommand> =
+    { projection = stockProjection
+      trigger = fun qty -> if qty < threshold then Some RequestReorder else None
+      decider = inventoryDecider }
+
+// Supplier domain for external orders
+
+type SupplierCommand =
+    | PlaceOrder of int
+
+type SupplierEvent =
+    | OrderPlaced of int
+    interface TypeShape.UnionContract.IUnionContract
+
+type SupplierState = int
+
+let supplierDecider : Decider<SupplierState, SupplierCommand, SupplierEvent> =
+    {
+        initial = 0
+        decide = fun cmd _state ->
+            match cmd with
+            | PlaceOrder qty when qty > 0 -> [ OrderPlaced qty ]
+            | _ -> []
+        evolve = fun state event ->
+            match event with
+            | OrderPlaced _ -> state + 1
+    }
+
+// Translator from inventory events to supplier commands
+
+let lastEventProjection : Projection<InventoryEvent option, InventoryEvent> =
+    { initial = None
+      project = fun _ e -> Some e }
+
+let reorderTranslator : Translator<InventoryEvent, InventoryEvent option, SupplierCommand> =
+    { projection = lastEventProjection
+      translate = function
+        | Some (ReorderRequested qty) -> Some (PlaceOrder qty)
+        | _ -> None }
+
+// Create the services
+
+let supplierService =
+    Service.createService supplierDecider "Supplier" None None
+
+let inventoryService =
+    Service.createService inventoryDecider "Inventory"
+        (Some lowStockAutomation)
+        (Some (reorderTranslator, supplierService))
+
+[<EntryPoint>]
+let main _ =
+    // log events from both services
+    let _ : IDisposable =
+        inventoryService.Subscribe (fun name events -> printfn "%A" (name, events))
+    let _ : IDisposable =
+        supplierService.Subscribe (fun name events -> printfn "%A" (name, events))
+
+    let inventoryApp =
+        GenericResource.configure
+            "Inventory"
+            "/inventory/%s"
+            "/inventory/%s/%s"
+            inventoryService
+            [ GenericResource.boxProjection "stock" stockProjection ]
+
+    let supplierApp =
+        GenericResource.configure
+            "Supplier"
+            "/supplier/%s"
+            "/supplier/%s/%s"
+            supplierService
+            []
+
+    let app = choose [ inventoryApp; supplierApp ]
+
+    Suave.Web.startWebServer Suave.Web.defaultConfig app
+    0
+

--- a/samples/TranslationApp/Program.fs
+++ b/samples/TranslationApp/Program.fs
@@ -77,7 +77,7 @@ let main _ =
             mirrorService
             [ GenericResource.boxProjection "count" countProjection ]
 
-    let app = Suave.Operators.choose [ counterApp; mirrorApp ]
+    let app = choose [ counterApp; mirrorApp ]
 
     Suave.Web.startWebServer Suave.Web.defaultConfig app
     0


### PR DESCRIPTION
## Summary
- add InventoryApp sample demonstrating all event modeling patterns
- fix sample usage of Suave `choose` combinator
- document new sample in README

## Testing
- `dotnet build samples/InventoryApp/InventoryApp.fsproj -c Release`
- `dotnet build samples/TranslationApp/TranslationApp.fsproj -c Release`
- `dotnet run --project tests/EventModeling.Tests/EventModeling.Tests.fsproj`


------
https://chatgpt.com/codex/tasks/task_b_683eea5477bc83309a0d38911392d49c