### PR TITLE
Add stream mapping parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ type Decider<'State,'Command,'Event> = {
 ```fsharp
 [<EntryPoint>]
 let main _ =
-    let service = Service.createService counterDecider "Counter" None None
+    let service = Service.createService counterDecider "Counter" None None Service.defaultStreamId
     let _ : System.IDisposable =
         service.Subscribe (fun name events -> printfn "%A" (name, events))
     let app =
@@ -102,12 +102,12 @@ let mirrorTranslator : TranslationPattern.Translator<Event, Event option, Comman
         | Some Incremented -> Some Increment
         | _ -> None }
 
-let mirrorService = Service.createService counterDecider "Mirror" None None
+let mirrorService = Service.createService counterDecider "Mirror" None None Service.defaultStreamId
 let counterService =
-    Service.createService counterDecider "Counter" None (Some (mirrorTranslator, mirrorService))
+    Service.createService counterDecider "Counter" None (Some (mirrorTranslator, mirrorService)) Service.defaultStreamId
 ```
 
-When `counterService` commits new events, the translator is invoked for each of them. Any produced commands are executed on the `mirrorService` using the same stream identifier. This example mirrors events within the same category, but by supplying a mapping function you could translate between different categories or even use completely different stream identifiers.
+When `counterService` commits new events, the translator is invoked for each of them. Any produced commands are executed on the `mirrorService` using the stream identifier returned from the mapping function (here `Service.defaultStreamId`). This example mirrors events within the same category, but by supplying a custom mapping you can translate between different categories or even use completely different stream identifiers.
 
 ### Running the AutomationApp sample
 

--- a/samples/AutomationApp/Program.fs
+++ b/samples/AutomationApp/Program.fs
@@ -49,7 +49,7 @@ let automation : AutomationPattern.Automation<int, State, Event, Command> =
 [<EntryPoint>]
 let main _ =
     let service =
-        Service.createService counterDecider "Counter" (Some automation) None
+        Service.createService counterDecider "Counter" (Some automation) None Service.defaultStreamId
     let _ : IDisposable =
         service.Subscribe (fun name events -> printfn "%A" (name, events))
     let app =

--- a/samples/CounterApp/Program.fs
+++ b/samples/CounterApp/Program.fs
@@ -32,7 +32,7 @@ let counterDecider : CommandPattern.Decider<State, Command, Event> = {
 
 [<EntryPoint>]
 let main _ =
-    let service = Service.createService counterDecider "Counter" None None
+    let service = Service.createService counterDecider "Counter" None None Service.defaultStreamId
     let _ : IDisposable =
         service.Subscribe (fun name events -> printfn "%A" (name, events))
     let app =

--- a/samples/InventoryApp/Program.fs
+++ b/samples/InventoryApp/Program.fs
@@ -107,12 +107,13 @@ let reorderTranslator : Translator<InventoryEvent, InventoryEvent option, Suppli
 // Create the services
 
 let supplierService =
-    Service.createService supplierDecider "Supplier" None None
+    Service.createService supplierDecider "Supplier" None None Service.defaultStreamId
 
 let inventoryService =
     Service.createService inventoryDecider "Inventory"
         (Some lowStockAutomation)
         (Some (reorderTranslator, supplierService))
+        Service.defaultStreamId
 
 [<EntryPoint>]
 let main _ =

--- a/samples/TranslationApp/Program.fs
+++ b/samples/TranslationApp/Program.fs
@@ -49,10 +49,10 @@ let mirrorTranslator : TranslationPattern.Translator<Event, Event option, Comman
         | _ -> None }
 
 let mirrorService =
-    Service.createService counterDecider "Mirror" None None
+    Service.createService counterDecider "Mirror" None None Service.defaultStreamId
 
 let counterService =
-    Service.createService counterDecider "Counter" None (Some (mirrorTranslator, mirrorService))
+    Service.createService counterDecider "Counter" None (Some (mirrorTranslator, mirrorService)) Service.defaultStreamId
 
 [<EntryPoint>]
 let main _ =

--- a/samples/ViewApp/Program.fs
+++ b/samples/ViewApp/Program.fs
@@ -44,7 +44,7 @@ let historyProjection : ViewPattern.Projection<Event list, Event> =
 
 [<EntryPoint>]
 let main _ =
-    let service = Service.createService counterDecider "Counter" None None
+    let service = Service.createService counterDecider "Counter" None None Service.defaultStreamId
     let _ : IDisposable =
         service.Subscribe (fun name events -> printfn "%A" (name, events))
     let app =


### PR DESCRIPTION
## Summary
- expose `Service.defaultStreamId`
- allow customizing the target stream id when creating a `Service`
- update samples and docs with the new argument

## Testing
- `dotnet run` in `tests/EventModeling.Tests`

------
https://chatgpt.com/codex/tasks/task_b_683ef0267d548330a44344ce0c66ce33