### PR TITLE
Fix stream name variable

### DIFF
--- a/Service.fs
+++ b/Service.fs
@@ -72,7 +72,7 @@ let createService<'View,'State,'Command,'Event,'TState,'TCommand,'TEvent,'TView
                 fun streamName events ->
                     let events' = service.Load streamName
                     let view = ViewPattern.hydrate automation'.projection events'
-                    let struct (name, streamId) =  FsCodec.StreamName.split streamName
+                    let struct (_, streamId) =  FsCodec.StreamName.split streamName
                     match automation'.trigger view with
                     | Some cmd -> Async.RunSynchronously <| service.Execute (streamId.ToString()) cmd
                     | None -> ()


### PR DESCRIPTION
## Summary
- ignore the first element of the tuple returned by `StreamName.split`

## Testing
- `dotnet build --no-restore tests/EventModeling.Tests/EventModeling.Tests.fsproj`
- `dotnet run --project tests/EventModeling.Tests/EventModeling.Tests.fsproj --no-build`


------
https://chatgpt.com/codex/tasks/task_b_683f3c520dd083309cfd7f078e2235b5