### PR TITLE
Add cross stream projections

### DIFF
--- a/GenericResource.fs
+++ b/GenericResource.fs
@@ -31,6 +31,11 @@ let boxProjection name (projection: ViewPattern.Projection<'View,'Event>) :
     string * ('Event list -> obj) =
     name, fun events -> ViewPattern.hydrate projection events |> box
 
+/// Box a category projection operating over multiple streams
+let boxCategoryProjection name (projection: ViewPattern.Projection<'View, ViewPattern.StreamEvent<'Event>>) :
+    string * (ViewPattern.StreamEvent<'Event> list -> obj) =
+    name, fun events -> ViewPattern.hydrate projection events |> box
+
 let deserialize<'TValue> : byte array -> Result<'TValue,string> = fun bytes ->
     try
         Ok <| JsonSerializer.Deserialize<'TValue>(bytes, jsonOptions)
@@ -49,6 +54,53 @@ let configure<'State,'Command,'Event>
             let key = FsCodec.StreamName.compose category [| id |] 
             let history = service.Load key
             match projections |> List.filter (fun (n,_) -> n = view) with
+            | [] -> return! BAD_REQUEST $"No view named '{view}'" ctx
+            | (_, hydrateView) :: _ ->
+                let view = hydrateView history
+                return! (toJson view) ctx
+        })
+        // GET /{resource}/{id}
+        GET >=> pathScan path (fun id ctx -> async {
+          let! state = service.Read id
+          return! toJson state ctx
+        })
+        // POST /{resource}/{id}
+        POST >=> pathScan path (fun id ctx -> async {
+            match deserialize<'Command> ctx.request.rawForm with
+            | Error msg -> return! BAD_REQUEST msg ctx
+            | Ok cmd ->
+                try
+                    do! service.Execute id cmd
+                    let! state = service.Read id
+                    return! (toJson state) ctx
+                with ex -> return! CONFLICT ex.Message ctx
+        })
+      ]
+
+/// Configure routes with additional category-level projections
+let configureWithCategory<'State,'Command,'Event>
+  (category : string)
+  (path: PrintfFormat<string -> WebPart, unit, string, WebPart, string> )
+  (viewPath: PrintfFormat<string -> string -> WebPart, unit, string, WebPart, string * string> )
+  (categoryViewPath: PrintfFormat<string -> WebPart, unit, string, WebPart, string>)
+  (service: Service<'State,'Command,'Event>)
+  (streamProjections: (string * ('Event list -> obj)) list)
+  (categoryProjections: (string * (ViewPattern.StreamEvent<'Event> list -> obj)) list)
+  : WebPart<HttpContext> =
+      choose [
+        GET >=> pathScan categoryViewPath (fun view ctx -> async {
+            match categoryProjections |> List.filter (fun (n,_) -> n = view) with
+            | [] -> return! BAD_REQUEST $"No view named '{view}'" ctx
+            | (_, hydrateView) :: _ ->
+                let events = service.LoadCategory()
+                let v = hydrateView events
+                return! (toJson v) ctx
+        })
+        // per-stream projections
+        GET >=> pathScan viewPath (fun (id,view) ctx -> async {
+            let key = FsCodec.StreamName.compose category [| id |]
+            let history = service.Load key
+            match streamProjections |> List.filter (fun (n,_) -> n = view) with
             | [] -> return! BAD_REQUEST $"No view named '{view}'" ctx
             | (_, hydrateView) :: _ ->
                 let view = hydrateView history

--- a/ViewPattern.fs
+++ b/ViewPattern.fs
@@ -5,6 +5,12 @@ type Projection<'View,'Event> = {
     project: 'View -> 'Event-> 'View
 }
 
+/// Wrapper carrying the originating stream id for a given event
+type StreamEvent<'Event> = {
+    StreamId: string
+    Event: 'Event
+}
+
 let replay = List.fold
 
 let hydrate : Projection<'View,'Event> -> 'Event list -> 'View = fun p ->

--- a/event-modeling.fsproj
+++ b/event-modeling.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>event_modeling</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.19.0</Version>
+    <Version>0.20.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- introduce `StreamEvent` for cross-stream projections
- store and expose category-wide events in `Service`
- support category projections in `GenericResource`
- test `LoadCategory` collects events across streams
- bump version to 0.20.0

## Testing
- `dotnet build tests/EventModeling.Tests/EventModeling.Tests.fsproj`
- `dotnet run --project tests/EventModeling.Tests/EventModeling.Tests.fsproj --no-build`


------
https://chatgpt.com/codex/tasks/task_b_684af8c3f6348330aac4a2b34354cc1e