### PR TITLE
Add CategoryApp sample for category projections

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,7 @@ Run `dotnet run --project samples/TranslationApp/TranslationApp.fsproj` to start
 ### Running the InventoryApp sample
 
 Run `dotnet run --project samples/InventoryApp/InventoryApp.fsproj` to start a minimal inventory service that demonstrates all four patterns with an automatic reorder workflow.
+
+### Running the CategoryApp sample
+
+Run `dotnet run --project samples/CategoryApp/CategoryApp.fsproj` to start a service exposing category-level views across all counters.

--- a/samples/CategoryApp/CategoryApp.fsproj
+++ b/samples/CategoryApp/CategoryApp.fsproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>false</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+    <ProjectReference Include="../../event-modeling.fsproj" />
+  </ItemGroup>
+</Project>

--- a/samples/CategoryApp/Program.fs
+++ b/samples/CategoryApp/Program.fs
@@ -1,0 +1,73 @@
+open System
+open Suave
+
+// Domain model from README
+
+type Event =
+    | Incremented
+    | Decremented
+    interface TypeShape.UnionContract.IUnionContract
+
+type Command =
+    | Increment
+    | Decrement
+
+type State =
+    | Zero
+    | Succ of State
+
+let counterDecider : CommandPattern.Decider<State, Command, Event> = {
+    initial = Zero
+    decide = fun cmd state ->
+        match cmd, state with
+        | Increment, _ -> [ Incremented ]
+        | Decrement, Zero -> []
+        | Decrement, Succ _ -> [ Decremented ]
+    evolve = fun state event ->
+        match event, state with
+        | Incremented, _ -> Succ state
+        | Decremented, Zero -> Zero
+        | Decremented, Succ state' -> state'
+}
+
+// Per-counter projection
+let countProjection : ViewPattern.Projection<int, Event> =
+    { initial = 0
+      project = fun count -> function
+        | Incremented -> count + 1
+        | Decremented -> count - 1 }
+
+// Category-level projections
+let totalProjection : ViewPattern.Projection<int, ViewPattern.StreamEvent<Event>> =
+    { initial = 0
+      project = fun total se ->
+        match se.Event with
+        | Incremented -> total + 1
+        | Decremented -> total - 1 }
+
+let allCountsProjection : ViewPattern.Projection<Map<string,int>, ViewPattern.StreamEvent<Event>> =
+    { initial = Map.empty
+      project = fun counts se ->
+        let current = counts |> Map.tryFind se.StreamId |> Option.defaultValue 0
+        let updated =
+            match se.Event with
+            | Incremented -> current + 1
+            | Decremented -> current - 1
+        counts |> Map.add se.StreamId updated }
+
+[<EntryPoint>]
+let main _ =
+    let service = Service.createService counterDecider "Counter" None None Service.defaultStreamId
+    let _ : IDisposable = service.Subscribe (fun name events -> printfn "%A" (name, events))
+    let app =
+        GenericResource.configureWithCategory
+            "Counter"
+            "/counter/%s"
+            "/counters/%s/%s"
+            "/counters/%s"
+            service
+            [ GenericResource.boxProjection "count" countProjection ]
+            [ GenericResource.boxCategoryProjection "total" totalProjection
+              GenericResource.boxCategoryProjection "all" allCountsProjection ]
+    Suave.Web.startWebServer Suave.Web.defaultConfig app
+    0

--- a/samples/CategoryApp/README.md
+++ b/samples/CategoryApp/README.md
@@ -1,0 +1,25 @@
+# CategoryApp Sample
+
+This sample demonstrates category-level projections. It exposes views for each counter as well as aggregated views across the whole `Counter` category.
+
+Run the sample with:
+
+```bash
+dotnet run --project samples/CategoryApp/CategoryApp.fsproj
+```
+
+Try the following commands:
+
+```bash
+# increment two counters
+curl localhost:8080/counter/1 -d '"Increment"'
+curl localhost:8080/counter/2 -d '"Increment"'
+
+# view individual counts
+curl localhost:8080/counters/1/count
+curl localhost:8080/counters/2/count
+
+# view all counts and the total
+curl localhost:8080/counters/all
+curl localhost:8080/counters/total
+```


### PR DESCRIPTION
## Summary
- add new CategoryApp sample with category-wide projections
- expose per-counter and category-level views
- document how to run the new sample and link to it from root README

## Testing
- `dotnet build`
- `dotnet run --project tests/EventModeling.Tests/EventModeling.Tests.fsproj`

------
https://chatgpt.com/codex/tasks/task_b_684bfc053c6483309cf00ab807f9e836