### PR TITLE
Introduce ScopedProjection

### DIFF
--- a/samples/AutomationApp/Program.fs
+++ b/samples/AutomationApp/Program.fs
@@ -58,6 +58,6 @@ let main _ =
             "/counters/%s"
             "/counters/%s/%s"
             service
-            [ GenericResource.boxProjection "count" countProjection ]
+            [ GenericResource.boxedStream "count" countProjection ]
     Suave.Web.startWebServer Suave.Web.defaultConfig app
     0

--- a/samples/CategoryApp/Program.fs
+++ b/samples/CategoryApp/Program.fs
@@ -66,8 +66,8 @@ let main _ =
             "/counters/%s/%s"
             "/counters/%s"
             service
-            [ GenericResource.boxProjection "count" countProjection ]
-            [ GenericResource.boxCategoryProjection "total" totalProjection
-              GenericResource.boxCategoryProjection "all" allCountsProjection ]
+            [ GenericResource.boxedStream "count" countProjection
+              GenericResource.boxedCategory "total" totalProjection
+              GenericResource.boxedCategory "all" allCountsProjection ]
     Suave.Web.startWebServer Suave.Web.defaultConfig app
     0

--- a/samples/InventoryApp/Program.fs
+++ b/samples/InventoryApp/Program.fs
@@ -129,7 +129,7 @@ let main _ =
             "/inventory/%s"
             "/inventory/%s/%s"
             inventoryService
-            [ GenericResource.boxProjection "stock" stockProjection ]
+            [ GenericResource.boxedStream "stock" stockProjection ]
 
     let supplierApp =
         GenericResource.configure

--- a/samples/TranslationApp/Program.fs
+++ b/samples/TranslationApp/Program.fs
@@ -67,7 +67,7 @@ let main _ =
             "/counters/%s"
             "/counters/%s/%s"
             counterService
-            [ GenericResource.boxProjection "count" countProjection ]
+            [ GenericResource.boxedStream "count" countProjection ]
 
     let mirrorApp =
         GenericResource.configure
@@ -75,7 +75,7 @@ let main _ =
             "/mirror/%s"
             "/mirror/%s/%s"
             mirrorService
-            [ GenericResource.boxProjection "count" countProjection ]
+            [ GenericResource.boxedStream "count" countProjection ]
 
     let app = choose [ counterApp; mirrorApp ]
 

--- a/samples/ViewApp/Program.fs
+++ b/samples/ViewApp/Program.fs
@@ -53,7 +53,7 @@ let main _ =
             "/counters/%s"
             "/counters/%s/%s"
             service
-            [ GenericResource.boxProjection "count" countProjection
-              GenericResource.boxProjection "history" historyProjection ]
+            [ GenericResource.boxedStream "count" countProjection
+              GenericResource.boxedStream "history" historyProjection ]
     Suave.Web.startWebServer Suave.Web.defaultConfig app
     0


### PR DESCRIPTION
## Summary
- support grouping stream and category projections via `ScopedProjection`
- add helpers `boxedStream` and `boxedCategory`
- update resource configuration to work with the new union type
- adjust samples to build a single projection list

## Testing
- `dotnet build --no-restore`
- `dotnet run --project tests/EventModeling.Tests/EventModeling.Tests.fsproj --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_b_684c2b2701ec8330aa847e9af03e6aaa