### PR TITLE
Introduce ServiceConfig builder helper

### DIFF
--- a/samples/AutomationApp/Program.fs
+++ b/samples/AutomationApp/Program.fs
@@ -49,7 +49,9 @@ let automation : AutomationPattern.Automation<int, State, Event, Command> =
 [<EntryPoint>]
 let main _ =
     let service =
-        Service.createService counterDecider "Counter" (Some automation) None Service.defaultStreamId
+        Service.ServiceConfig.create "Counter"
+        |> Service.ServiceConfig.withAutomation automation
+        |> Service.createServiceWith counterDecider
     let _ : IDisposable =
         service.Subscribe (fun name events -> printfn "%A" (name, events))
     let app =

--- a/samples/CategoryApp/Program.fs
+++ b/samples/CategoryApp/Program.fs
@@ -57,7 +57,9 @@ let allCountsProjection : ViewPattern.ProjectionSpec<Map<string,int>, ViewPatter
 
 [<EntryPoint>]
 let main _ =
-    let service = Service.createService counterDecider "Counter" None None Service.defaultStreamId
+    let service =
+        Service.ServiceConfig.create "Counter"
+        |> Service.createServiceWith counterDecider
     let _ : IDisposable = service.Subscribe (fun name events -> printfn "%A" (name, events))
     let app =
         GenericResource.configureWithCategory

--- a/samples/CounterApp/Program.fs
+++ b/samples/CounterApp/Program.fs
@@ -32,7 +32,9 @@ let counterDecider : CommandPattern.Decider<State, Command, Event> = {
 
 [<EntryPoint>]
 let main _ =
-    let service = Service.createService counterDecider "Counter" None None Service.defaultStreamId
+    let service =
+        Service.ServiceConfig.create "Counter"
+        |> Service.createServiceWith counterDecider
     let _ : IDisposable =
         service.Subscribe (fun name events -> printfn "%A" (name, events))
     let app =

--- a/samples/InventoryApp/Program.fs
+++ b/samples/InventoryApp/Program.fs
@@ -107,13 +107,14 @@ let reorderTranslator : Translator<InventoryEvent, InventoryEvent option, Suppli
 // Create the services
 
 let supplierService =
-    Service.createService supplierDecider "Supplier" None None Service.defaultStreamId
+    Service.ServiceConfig.create "Supplier"
+    |> Service.createServiceWith supplierDecider
 
 let inventoryService =
-    Service.createService inventoryDecider "Inventory"
-        (Some lowStockAutomation)
-        (Some (reorderTranslator, supplierService))
-        Service.defaultStreamId
+    Service.ServiceConfig.create "Inventory"
+    |> Service.ServiceConfig.withAutomation lowStockAutomation
+    |> Service.ServiceConfig.withTranslation (reorderTranslator, supplierService)
+    |> Service.createServiceWith inventoryDecider
 
 [<EntryPoint>]
 let main _ =

--- a/samples/TranslationApp/Program.fs
+++ b/samples/TranslationApp/Program.fs
@@ -49,10 +49,13 @@ let mirrorTranslator : TranslationPattern.Translator<Event, Event option, Comman
         | _ -> None }
 
 let mirrorService =
-    Service.createService counterDecider "Mirror" None None Service.defaultStreamId
+    Service.ServiceConfig.create "Mirror"
+    |> Service.createServiceWith counterDecider
 
 let counterService =
-    Service.createService counterDecider "Counter" None (Some (mirrorTranslator, mirrorService)) Service.defaultStreamId
+    Service.ServiceConfig.create "Counter"
+    |> Service.ServiceConfig.withTranslation (mirrorTranslator, mirrorService)
+    |> Service.createServiceWith counterDecider
 
 [<EntryPoint>]
 let main _ =

--- a/samples/ViewApp/Program.fs
+++ b/samples/ViewApp/Program.fs
@@ -44,7 +44,9 @@ let historyProjection : ViewPattern.ProjectionSpec<Event list, Event> =
 
 [<EntryPoint>]
 let main _ =
-    let service = Service.createService counterDecider "Counter" None None Service.defaultStreamId
+    let service =
+        Service.ServiceConfig.create "Counter"
+        |> Service.createServiceWith counterDecider
     let _ : IDisposable =
         service.Subscribe (fun name events -> printfn "%A" (name, events))
     let app =

--- a/tests/EventModeling.Tests/Tests.fs
+++ b/tests/EventModeling.Tests/Tests.fs
@@ -127,7 +127,9 @@ let translationTests =
 
 [<Tests>]
 let crossStreamTests =
-    let service = Service.createService counterDecider "Counter" None None Service.defaultStreamId
+    let service =
+        Service.ServiceConfig.create "Counter"
+        |> Service.createServiceWith counterDecider
     testCase "loadCategory aggregates events across streams" <| fun _ ->
         Async.RunSynchronously <| service.Execute "a" Increment
         Async.RunSynchronously <| service.Execute "b" Increment
@@ -137,7 +139,9 @@ let crossStreamTests =
 
 [<Tests>]
 let categoryProjectionTests =
-    let service = Service.createService counterDecider "Counter" None None Service.defaultStreamId
+    let service =
+        Service.ServiceConfig.create "Counter"
+        |> Service.createServiceWith counterDecider
 
     let totalProjection : ProjectionSpec<int, ViewPattern.StreamEvent<Event>> =
         { initial = 0


### PR DESCRIPTION
## Summary
- add `ServiceConfig` builder module for easier service configuration
- refactor samples, tests and docs to use the builder style

## Testing
- `dotnet build -c Release`
- `dotnet run --project tests/EventModeling.Tests/EventModeling.Tests.fsproj`


------
https://chatgpt.com/codex/tasks/task_b_684c53dc68ac8330ba1d415d4a4ea3ec