### PR TITLE
Align projection type with view composition intent

### DIFF
--- a/ViewPattern.fs
+++ b/ViewPattern.fs
@@ -12,9 +12,11 @@ type StreamEvent<'Event> = {
 }
 
 /// Distinguishes between per-stream and category-level projections
+/// Identify whether a projection operates over a single stream or an entire category
+/// The projection specification itself does not carry a view name
 type Projection<'View,'Event> =
-    | StreamProjection of string * ProjectionSpec<'View,'Event>
-    | CategoryProjection of string * ProjectionSpec<'View, StreamEvent<'Event>>
+    | StreamProjection of ProjectionSpec<'View,'Event>
+    | CategoryProjection of ProjectionSpec<'View, StreamEvent<'Event>>
 
 let replay = List.fold
 

--- a/event-modeling.fsproj
+++ b/event-modeling.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>event_modeling</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.22.0</Version>
+    <Version>0.23.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- remove the view name from `ViewPattern.Projection`
- bump library version to 0.23.0

## Testing
- `dotnet build -c Release`
- `dotnet run --project tests/EventModeling.Tests/EventModeling.Tests.fsproj`


------
https://chatgpt.com/codex/tasks/task_b_6851bb26fb8c8330a02bb9fe9f25e4a2