### PR TITLE
Align projection type with view composition intent

### DIFF
--- a/ViewPattern.fs
+++ b/ViewPattern.fs
@@ -12,9 +12,11 @@ type StreamEvent<'Event> = {
 }
 
 /// Distinguishes between per-stream and category-level projections
+/// Identify whether a projection operates over a single stream or an entire category
+/// The projection specification itself does not carry a view name
 type Projection<'View,'Event> =
-    | StreamProjection of string * ProjectionSpec<'View,'Event>
-    | CategoryProjection of string * ProjectionSpec<'View, StreamEvent<'Event>>
+    | StreamProjection of ProjectionSpec<'View,'Event>
+    | CategoryProjection of ProjectionSpec<'View, StreamEvent<'Event>>
 
 let replay = List.fold
 

--- a/event-modeling.fsproj
+++ b/event-modeling.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>event_modeling</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.22.0</Version>
+    <Version>0.24.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/AutomationApp/Program.fs
+++ b/samples/AutomationApp/Program.fs
@@ -60,6 +60,6 @@ let main _ =
             "/counters/%s"
             "/counters/%s/%s"
             service
-            [ GenericResource.boxedStream "count" countProjection ]
+            [ GenericResource.box "count" (ViewPattern.StreamProjection countProjection) ]
     Suave.Web.startWebServer Suave.Web.defaultConfig app
     0

--- a/samples/CategoryApp/Program.fs
+++ b/samples/CategoryApp/Program.fs
@@ -68,8 +68,8 @@ let main _ =
             "/counters/%s/%s"
             "/counters/%s"
             service
-            [ GenericResource.boxedStream "count" countProjection
-              GenericResource.boxedCategory "total" totalProjection
-              GenericResource.boxedCategory "all" allCountsProjection ]
+            [ GenericResource.box "count" (ViewPattern.StreamProjection countProjection)
+              GenericResource.box "total" (ViewPattern.CategoryProjection totalProjection)
+              GenericResource.box "all" (ViewPattern.CategoryProjection allCountsProjection) ]
     Suave.Web.startWebServer Suave.Web.defaultConfig app
     0

--- a/samples/InventoryApp/Program.fs
+++ b/samples/InventoryApp/Program.fs
@@ -130,7 +130,7 @@ let main _ =
             "/inventory/%s"
             "/inventory/%s/%s"
             inventoryService
-            [ GenericResource.boxedStream "stock" stockProjection ]
+            [ GenericResource.box "stock" (ViewPattern.StreamProjection stockProjection) ]
 
     let supplierApp =
         GenericResource.configure

--- a/samples/TranslationApp/Program.fs
+++ b/samples/TranslationApp/Program.fs
@@ -70,7 +70,7 @@ let main _ =
             "/counters/%s"
             "/counters/%s/%s"
             counterService
-            [ GenericResource.boxedStream "count" countProjection ]
+            [ GenericResource.box "count" (ViewPattern.StreamProjection countProjection) ]
 
     let mirrorApp =
         GenericResource.configure
@@ -78,7 +78,7 @@ let main _ =
             "/mirror/%s"
             "/mirror/%s/%s"
             mirrorService
-            [ GenericResource.boxedStream "count" countProjection ]
+            [ GenericResource.box "count" (ViewPattern.StreamProjection countProjection) ]
 
     let app = choose [ counterApp; mirrorApp ]
 

--- a/samples/ViewApp/Program.fs
+++ b/samples/ViewApp/Program.fs
@@ -55,7 +55,7 @@ let main _ =
             "/counters/%s"
             "/counters/%s/%s"
             service
-            [ GenericResource.boxedStream "count" countProjection
-              GenericResource.boxedStream "history" historyProjection ]
+            [ GenericResource.box "count" (ViewPattern.StreamProjection countProjection)
+              GenericResource.box "history" (ViewPattern.StreamProjection historyProjection) ]
     Suave.Web.startWebServer Suave.Web.defaultConfig app
     0


### PR DESCRIPTION
## Summary
- remove view name from projection union
- add `GenericResource.box` to compose views with explicit `StreamProjection`/`CategoryProjection`
- bump library version to 0.24.0

## Testing
- `dotnet build -c Release`
- `dotnet run --project tests/EventModeling.Tests/EventModeling.Tests.fsproj`


------
https://chatgpt.com/codex/tasks/task_b_6851bb26fb8c8330a02bb9fe9f25e4a2