### PR TITLE
Merge GenericResource configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,8 @@ let main _ =
     let _ : System.IDisposable =
         service.Subscribe (fun name events -> printfn "%A" (name, events))
     let app =
-        GenericResource.configure
-            "Counter"
-            "/counters/%s"
-            "/counters/%s/%s"
-            service
-            []
+        GenericResource.ResourceConfig.create "Counter" "/counters/%s" "/counters/%s/%s" service []
+        |> GenericResource.configure
     Suave.Web.startWebServer Suave.Web.defaultConfig app
     0
 ```

--- a/event-modeling.fsproj
+++ b/event-modeling.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>event_modeling</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.24.0</Version>
+    <Version>0.25.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/AutomationApp/Program.fs
+++ b/samples/AutomationApp/Program.fs
@@ -55,11 +55,8 @@ let main _ =
     let _ : IDisposable =
         service.Subscribe (fun name events -> printfn "%A" (name, events))
     let app =
-        GenericResource.configure
-            "Counter"
-            "/counters/%s"
-            "/counters/%s/%s"
-            service
+        GenericResource.ResourceConfig.create "Counter" "/counters/%s" "/counters/%s/%s" service
             [ GenericResource.box "count" (ViewPattern.StreamProjection countProjection) ]
+        |> GenericResource.configure
     Suave.Web.startWebServer Suave.Web.defaultConfig app
     0

--- a/samples/CategoryApp/Program.fs
+++ b/samples/CategoryApp/Program.fs
@@ -62,14 +62,11 @@ let main _ =
         |> Service.createServiceWith counterDecider
     let _ : IDisposable = service.Subscribe (fun name events -> printfn "%A" (name, events))
     let app =
-        GenericResource.configureWithCategory
-            "Counter"
-            "/counter/%s"
-            "/counters/%s/%s"
-            "/counters/%s"
-            service
+        GenericResource.ResourceConfig.create "Counter" "/counter/%s" "/counters/%s/%s" service
             [ GenericResource.box "count" (ViewPattern.StreamProjection countProjection)
               GenericResource.box "total" (ViewPattern.CategoryProjection totalProjection)
               GenericResource.box "all" (ViewPattern.CategoryProjection allCountsProjection) ]
+        |> GenericResource.ResourceConfig.withCategoryViewPath "/counters/%s"
+        |> GenericResource.configure
     Suave.Web.startWebServer Suave.Web.defaultConfig app
     0

--- a/samples/CounterApp/Program.fs
+++ b/samples/CounterApp/Program.fs
@@ -38,12 +38,8 @@ let main _ =
     let _ : IDisposable =
         service.Subscribe (fun name events -> printfn "%A" (name, events))
     let app =
-        GenericResource.configure
-            "Counter"
-            "/counters/%s"
-            "/counters/%s/%s"
-            service
-            []
+        GenericResource.ResourceConfig.create "Counter" "/counters/%s" "/counters/%s/%s" service []
+        |> GenericResource.configure
     Suave.Web.startWebServer Suave.Web.defaultConfig app
     0
 

--- a/samples/InventoryApp/Program.fs
+++ b/samples/InventoryApp/Program.fs
@@ -125,20 +125,13 @@ let main _ =
         supplierService.Subscribe (fun name events -> printfn "%A" (name, events))
 
     let inventoryApp =
-        GenericResource.configure
-            "Inventory"
-            "/inventory/%s"
-            "/inventory/%s/%s"
-            inventoryService
+        GenericResource.ResourceConfig.create "Inventory" "/inventory/%s" "/inventory/%s/%s" inventoryService
             [ GenericResource.box "stock" (ViewPattern.StreamProjection stockProjection) ]
+        |> GenericResource.configure
 
     let supplierApp =
-        GenericResource.configure
-            "Supplier"
-            "/supplier/%s"
-            "/supplier/%s/%s"
-            supplierService
-            []
+        GenericResource.ResourceConfig.create "Supplier" "/supplier/%s" "/supplier/%s/%s" supplierService []
+        |> GenericResource.configure
 
     let app = choose [ inventoryApp; supplierApp ]
 

--- a/samples/TranslationApp/Program.fs
+++ b/samples/TranslationApp/Program.fs
@@ -65,20 +65,14 @@ let main _ =
         mirrorService.Subscribe (fun name events -> printfn "%A" (name, events))
 
     let counterApp =
-        GenericResource.configure
-            "Counter"
-            "/counters/%s"
-            "/counters/%s/%s"
-            counterService
+        GenericResource.ResourceConfig.create "Counter" "/counters/%s" "/counters/%s/%s" counterService
             [ GenericResource.box "count" (ViewPattern.StreamProjection countProjection) ]
+        |> GenericResource.configure
 
     let mirrorApp =
-        GenericResource.configure
-            "Mirror"
-            "/mirror/%s"
-            "/mirror/%s/%s"
-            mirrorService
+        GenericResource.ResourceConfig.create "Mirror" "/mirror/%s" "/mirror/%s/%s" mirrorService
             [ GenericResource.box "count" (ViewPattern.StreamProjection countProjection) ]
+        |> GenericResource.configure
 
     let app = choose [ counterApp; mirrorApp ]
 

--- a/samples/ViewApp/Program.fs
+++ b/samples/ViewApp/Program.fs
@@ -50,12 +50,9 @@ let main _ =
     let _ : IDisposable =
         service.Subscribe (fun name events -> printfn "%A" (name, events))
     let app =
-        GenericResource.configure
-            "Counter"
-            "/counters/%s"
-            "/counters/%s/%s"
-            service
+        GenericResource.ResourceConfig.create "Counter" "/counters/%s" "/counters/%s/%s" service
             [ GenericResource.box "count" (ViewPattern.StreamProjection countProjection)
               GenericResource.box "history" (ViewPattern.StreamProjection historyProjection) ]
+        |> GenericResource.configure
     Suave.Web.startWebServer Suave.Web.defaultConfig app
     0

--- a/samples/ViewApp/README.md
+++ b/samples/ViewApp/README.md
@@ -1,6 +1,6 @@
 # ViewApp Sample
 
-This sample builds on the basic counter domain and demonstrates the **View Pattern**. It exposes two projections via HTTP using `GenericResource.configure`:
+This sample builds on the basic counter domain and demonstrates the **View Pattern**. It exposes two projections via HTTP using `GenericResource.configure` with a `ResourceConfig`:
 
 - `count` – the current numeric value of the counter
 - `history` – the full list of events applied to the counter


### PR DESCRIPTION
## Summary
- add `ResourceConfig` builder for `GenericResource`
- merge `configure` and `configureWithCategory` functions
- update README and sample apps to use the new builder
- bump version to 0.25.0

## Testing
- `dotnet build -c Release`
- `dotnet run --project tests/EventModeling.Tests/EventModeling.Tests.fsproj`


------
https://chatgpt.com/codex/tasks/task_b_6851c8b9df7083308fdf402cc83b198e