### PR TITLE
Update default routing

### DIFF
--- a/GenericResource.fs
+++ b/GenericResource.fs
@@ -91,16 +91,19 @@ module ResourceConfig =
             if category.EndsWith "s" then category
             elif category.EndsWith "y" then category.Substring(0, category.Length - 1) + "ies"
             else category + "s"
-        let lower = plural.ToLowerInvariant()
-        let path = PrintfFormat<string -> WebPart, unit, string, WebPart, string>(sprintf "/%s/%%s" lower)
+        let lowerPlural = plural.ToLowerInvariant()
+        let lowerSingular = category.ToLowerInvariant()
+        let path = PrintfFormat<string -> WebPart, unit, string, WebPart, string>(sprintf "/%s/%%s" lowerSingular)
         let viewPath =
-            PrintfFormat<string -> string -> WebPart, unit, string, WebPart, string * string>(sprintf "/%s/%%s/%%s" lower)
+            PrintfFormat<string -> string -> WebPart, unit, string, WebPart, string * string>(sprintf "/%s/%%s/%%s" lowerSingular)
+        let categoryViewPath =
+            PrintfFormat<string -> WebPart, unit, string, WebPart, string>(sprintf "/%s/%%s" lowerPlural)
         { category = category
           path = path
           viewPath = viewPath
           service = service
           projections = []
-          categoryViewPath = None }
+          categoryViewPath = Some categoryViewPath }
 
     /// Set the route to use when loading a stream
     let withPath

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ let main _ =
 
 ### Test run your API
 
-Post the Increment command to counter 1: `curl localhost:8080/counters/1 -d '"Increment"'`
+Post the Increment command to counter 1: `curl localhost:8080/counter/1 -d '"Increment"'`
 
-Get the current state of counter 1: `curl localhost:8080/counters/1`
+Get the current state of counter 1: `curl localhost:8080/counter/1`
 
 ### Running the CounterApp sample
 

--- a/event-modeling.fsproj
+++ b/event-modeling.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>event_modeling</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.26.0</Version>
+    <Version>0.27.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/AutomationApp/README.md
+++ b/samples/AutomationApp/README.md
@@ -14,11 +14,11 @@ Try the following sequence of commands:
 
 ```bash
 # increment to 1
-curl localhost:8080/counters/1 -d '"Increment"'
+curl localhost:8080/counter/1 -d '"Increment"'
 
 # decrement back to 0 – automation immediately increments again
-curl localhost:8080/counters/1 -d '"Decrement"'
+curl localhost:8080/counter/1 -d '"Decrement"'
 
 # inspect the current count (should be 1)
-curl localhost:8080/counters/1/count
+curl localhost:8080/counter/1/count
 ```

--- a/samples/CategoryApp/Program.fs
+++ b/samples/CategoryApp/Program.fs
@@ -63,14 +63,11 @@ let main _ =
     let _ : IDisposable = service.Subscribe (fun name events -> printfn "%A" (name, events))
     let app =
         GenericResource.ResourceConfig.create "Counter" service
-        |> GenericResource.ResourceConfig.withPath (PrintfFormat<string -> WebPart, unit, string, WebPart, string> "/counter/%s")
-        |> GenericResource.ResourceConfig.withViewPath (PrintfFormat<string -> string -> WebPart, unit, string, WebPart, string * string> "/counters/%s/%s")
         |> GenericResource.ResourceConfig.withProjections [
             GenericResource.box "count" (ViewPattern.StreamProjection countProjection)
             GenericResource.box "total" (ViewPattern.CategoryProjection totalProjection)
             GenericResource.box "all" (ViewPattern.CategoryProjection allCountsProjection)
           ]
-        |> GenericResource.ResourceConfig.withCategoryViewPath "/counters/%s"
         |> GenericResource.configure
     Suave.Web.startWebServer Suave.Web.defaultConfig app
     0

--- a/samples/InventoryApp/Program.fs
+++ b/samples/InventoryApp/Program.fs
@@ -126,15 +126,11 @@ let main _ =
 
     let inventoryApp =
         GenericResource.ResourceConfig.create "Inventory" inventoryService
-        |> GenericResource.ResourceConfig.withPath (PrintfFormat<string -> WebPart, unit, string, WebPart, string> "/inventory/%s")
-        |> GenericResource.ResourceConfig.withViewPath (PrintfFormat<string -> string -> WebPart, unit, string, WebPart, string * string> "/inventory/%s/%s")
         |> GenericResource.ResourceConfig.withProjections [ GenericResource.box "stock" (ViewPattern.StreamProjection stockProjection) ]
         |> GenericResource.configure
 
     let supplierApp =
         GenericResource.ResourceConfig.create "Supplier" supplierService
-        |> GenericResource.ResourceConfig.withPath (PrintfFormat<string -> WebPart, unit, string, WebPart, string> "/supplier/%s")
-        |> GenericResource.ResourceConfig.withViewPath (PrintfFormat<string -> string -> WebPart, unit, string, WebPart, string * string> "/supplier/%s/%s")
         |> GenericResource.configure
 
     let app = choose [ inventoryApp; supplierApp ]

--- a/samples/TranslationApp/Program.fs
+++ b/samples/TranslationApp/Program.fs
@@ -71,8 +71,6 @@ let main _ =
 
     let mirrorApp =
         GenericResource.ResourceConfig.create "Mirror" mirrorService
-        |> GenericResource.ResourceConfig.withPath (PrintfFormat<string -> WebPart, unit, string, WebPart, string> "/mirror/%s")
-        |> GenericResource.ResourceConfig.withViewPath (PrintfFormat<string -> string -> WebPart, unit, string, WebPart, string * string> "/mirror/%s/%s")
         |> GenericResource.ResourceConfig.withProjections [ GenericResource.box "count" (ViewPattern.StreamProjection countProjection) ]
         |> GenericResource.configure
 

--- a/samples/TranslationApp/README.md
+++ b/samples/TranslationApp/README.md
@@ -15,13 +15,13 @@ Try the following commands:
 
 ```bash
 # increment the main counter
-curl localhost:8080/counters/1 -d '"Increment"'
+curl localhost:8080/counter/1 -d '"Increment"'
 
 # the mirror service has also incremented
 curl localhost:8080/mirror/1/count
 
 # decrement only affects the main counter
-curl localhost:8080/counters/1 -d '"Decrement"'
+curl localhost:8080/counter/1 -d '"Decrement"'
 
 # mirror count remains 1
 curl localhost:8080/mirror/1/count

--- a/samples/ViewApp/README.md
+++ b/samples/ViewApp/README.md
@@ -15,11 +15,11 @@ Then retrieve views, for example:
 
 ```bash
 # send a command
-curl localhost:8080/counters/1 -d '"Increment"'
+curl localhost:8080/counter/1 -d '"Increment"'
 
 # view the current count
-curl localhost:8080/counters/1/count
+curl localhost:8080/counter/1/count
 
 # view event history
-curl localhost:8080/counters/1/history
+curl localhost:8080/counter/1/history
 ```


### PR DESCRIPTION
## Summary
- default stream endpoints use singular name
- auto-add plural category view path
- update docs and samples
- bump package version to 0.27.0

## Testing
- `dotnet build -c Release`
- `dotnet run --project tests/EventModeling.Tests/EventModeling.Tests.fsproj`


------
https://chatgpt.com/codex/tasks/task_b_68531eb244f88330aff4636f8b207dee