### PR TITLE
Add store configuration to service builder

### DIFF
--- a/event-modeling.fsproj
+++ b/event-modeling.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>event_modeling</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.27.0</Version>
+    <Version>0.29.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/EventModeling.Tests/Tests.fs
+++ b/tests/EventModeling.Tests/Tests.fs
@@ -137,9 +137,9 @@ let serviceTranslationTests =
             | _ -> None }
     testCase "service translates events into commands" <| fun _ ->
         let mirrorService =
-            Service.createService counterDecider "Mirror" None None Service.defaultStreamId
+            Service.createService counterDecider "Mirror" None None Service.defaultStreamId None
         let counterService =
-            Service.createService counterDecider "Counter" None (Some (translator, mirrorService)) Service.defaultStreamId
+            Service.createService counterDecider "Counter" None (Some (translator, mirrorService)) Service.defaultStreamId None
         Async.RunSynchronously <| counterService.Execute "a" Increment
         let events =
             FsCodec.StreamName.compose "Mirror" [| "a" |]


### PR DESCRIPTION
## Summary
- allow users to supply a custom `Store` when building a service
- document how to inject a persistent Equinox store
- update tests for new API
- bump version to 0.29.0

## Testing
- `dotnet build -c Release`
- `dotnet run --project tests/EventModeling.Tests/EventModeling.Tests.fsproj`


------
https://chatgpt.com/codex/tasks/task_b_685398a7047483308e6e6e5109f78028