### PR TITLE
Introduce Equinox store helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,36 +139,22 @@ To persist events simply reference another Equinox store implementation in your
 project file, for example:
 
 ```xml
+<PackageReference Include="Equinox.EventStoreDb" Version="4.0.0" />
+<PackageReference Include="EventStore.Client" Version="21.10.2" />
 <PackageReference Include="Equinox.CosmosStore" Version="4.0.0" />
 <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.36.0" />
 ```
 
-Then create a store and inject it when building the service:
-
-```fsharp
-let connector =
-    Equinox.CosmosStore.Discovery.FromConnectionString "<connection-string>"
-let cosmos = Equinox.CosmosStore.CosmosStoreClient connector
-let cat =
-    Equinox.CosmosStore.CosmosStoreCategory(
-        cosmos,
-        categoryName,
-        codec,
-        Array.fold decider.evolve,
-        decider.initial)
-
-let store =
-    { category = cat
-      subscribe = (fun _ -> { new System.IDisposable with member _.Dispose() = () })
-      load = fun _ -> []
-      loadCategory = fun () -> [] }
-```
-
-Supply this store via `Service.ServiceConfig.withStore`:
+Then select the backing store when building the service:
 
 ```fsharp
 let service =
     Service.ServiceConfig.create categoryName
-    |> Service.ServiceConfig.withStore store
+    |> Service.ServiceConfig.withEventStoreDB "<esdb-connection-string>"
+    |> Service.createServiceWith decider
+
+let cosmosService =
+    Service.ServiceConfig.create categoryName
+    |> Service.ServiceConfig.withCosmosDB "<cosmos-connection-string>"
     |> Service.createServiceWith decider
 ```

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ project file, for example:
 
 ```xml
 <PackageReference Include="Equinox.EventStoreDb" Version="4.0.0" />
-<PackageReference Include="EventStore.Client" Version="21.10.2" />
+<PackageReference Include="EventStore.Client" Version="22.0.0" />
 <PackageReference Include="Equinox.CosmosStore" Version="4.0.0" />
 <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.36.0" />
 ```

--- a/Service.fs
+++ b/Service.fs
@@ -163,20 +163,21 @@ let createService<'View,'State,'Command,'Event,'TState,'TCommand,'TEvent,'TView
                 |> ValueOption.toOption
 
             let subscribe callback =
+                let eventAppeared _ ev _ =
+                    match FsCodec.StreamName.tryParse ev.Event.EventStreamId with
+                    | ValueSome sn when FsCodec.StreamName.category sn = categoryName ->
+                        match decode ev with
+                        | Some e -> callback sn [ e ]
+                        | None -> ()
+                    | _ -> ()
+                    System.Threading.Tasks.Task.CompletedTask
                 let filter =
                     EventStore.Client.SubscriptionFilterOptions(
                         EventStore.Client.StreamFilter.Prefix categoryName)
                 let sub =
                     client.SubscribeToAllAsync(
                         EventStore.Client.Position.Start,
-                        fun _ ev _ ->
-                            match FsCodec.StreamName.tryParse ev.Event.EventStreamId with
-                            | ValueSome sn when FsCodec.StreamName.category sn = categoryName ->
-                                match decode ev with
-                                | Some e -> callback sn [ e ]
-                                | None -> ()
-                            | _ -> ()
-                            System.Threading.Tasks.Task.CompletedTask,
+                        eventAppeared,
                         false,
                         filter)
                 { new System.IDisposable with member _.Dispose() = sub.Result.Dispose() }

--- a/Service.fs
+++ b/Service.fs
@@ -164,13 +164,14 @@ let createService<'View,'State,'Command,'Event,'TState,'TCommand,'TEvent,'TView
 
             let subscribe callback =
                 let eventAppeared _ ev _ =
-                    match FsCodec.StreamName.tryParse ev.Event.EventStreamId with
-                    | ValueSome sn when FsCodec.StreamName.category sn = categoryName ->
-                        match decode ev with
-                        | Some e -> callback sn [ e ]
-                        | None -> ()
-                    | _ -> ()
-                    System.Threading.Tasks.Task.CompletedTask
+                    task {
+                        match FsCodec.StreamName.tryParse ev.Event.EventStreamId with
+                        | ValueSome sn when FsCodec.StreamName.category sn = categoryName ->
+                            match decode ev with
+                            | Some e -> callback sn [ e ]
+                            | None -> ()
+                        | _ -> ()
+                    }
                 let filter =
                     EventStore.Client.SubscriptionFilterOptions(
                         EventStore.Client.StreamFilter.Prefix categoryName)

--- a/event-modeling.fsproj
+++ b/event-modeling.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>event_modeling</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.32.0</Version>
+    <Version>0.33.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/event-modeling.fsproj
+++ b/event-modeling.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>event_modeling</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.33.0</Version>
+    <Version>0.34.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,7 +17,7 @@
 
     <PackageReference Include="Equinox.MemoryStore" Version="4.0.0" />
     <PackageReference Include="Equinox.EventStoreDb" Version="4.0.0" />
-    <PackageReference Include="EventStore.Client" Version="21.10.2" />
+    <PackageReference Include="EventStore.Client" Version="22.0.0" />
     <PackageReference Include="Equinox.CosmosStore" Version="4.0.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.36.0" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.3" />

--- a/event-modeling.fsproj
+++ b/event-modeling.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>event_modeling</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.31.0</Version>
+    <Version>0.32.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/event-modeling.fsproj
+++ b/event-modeling.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>event_modeling</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.29.0</Version>
+    <Version>0.31.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +16,10 @@
     <Compile Include="GenericResource.fs" />
 
     <PackageReference Include="Equinox.MemoryStore" Version="4.0.0" />
+    <PackageReference Include="Equinox.EventStoreDb" Version="4.0.0" />
+    <PackageReference Include="EventStore.Client" Version="21.10.2" />
+    <PackageReference Include="Equinox.CosmosStore" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.36.0" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.3" />
     <PackageReference Include="FSharp.SystemTextJson" Version="1.3.13" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />


### PR DESCRIPTION
## Summary
- add `StoreChoice` union and store helper functions
- allow configuring services with `withEventStoreDB` and `withCosmosDB`
- fill in event store and cosmos implementations
- bump version to 0.31.0

## Testing
- `dotnet build -c Release` *(fails: Failed to restore packages)*
- `dotnet run --project tests/EventModeling.Tests/EventModeling.Tests.fsproj` *(fails: Failed to restore packages)*

------
https://chatgpt.com/codex/tasks/task_b_6853db7d6f4c8330ac4b5d4c57c785db